### PR TITLE
flush after string write - Iterable may produce delayed chunks

### DIFF
--- a/src/java/ring/adapter/jdk/IO.java
+++ b/src/java/ring/adapter/jdk/IO.java
@@ -18,6 +18,7 @@ public class IO {
         final byte[] buf = s.getBytes(StandardCharsets.UTF_8);
         try {
             out.write(buf);
+            out.flush();
         } catch (IOException e) {
             throw Err.error("could not transfer a string into the output stream");
         }


### PR DESCRIPTION
This PR flushes the `OutputStream` after every string write, so that the output is not buffered/delayed if the response body is a `java.lang.Iterable` and the chunks arrive at delayed intervals. This PR is a workaround for #2.

Consider the following usage sample emulating SSE:

```clojure
(defn make-seq []
  (Thread/sleep #_10 1000)
  (str "data: " (System/currentTimeMillis) "\n\n"))

(defn handler [request]
  {:status 200
   :headers {"Content-Type" "text/event-stream"}
   :body (repeatedly make-seq)})
```